### PR TITLE
Explicitly give slide ratio in options

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
 
     <script type="text/javascript">
         var options = {sourceUrl: "talk.md",
-                       highlightStyle: "tomorrow"};
+                       highlightStyle: "tomorrow",
+                       ratio: "4:3"};
         var renderMath = function() {
             renderMathInElement(document.body, {delimiters: [
                 {left: "$$", right: "$$", display: true},


### PR DESCRIPTION
The default ratio is 4:3 but having it explicitly stated makes it easier to change and read as a user. Example: The user might want to have a 16:9 ratio, which requires changing just a single line in the template now.