### PR TITLE
Specify slideNumberFormat option in options

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
     <script type="text/javascript">
         var options = {sourceUrl: "talk.md",
                        highlightStyle: "tomorrow",
-                       ratio: "4:3"};
+                       ratio: "4:3",
+                       slideNumberFormat: "%current% / %total%"};
         var renderMath = function() {
             renderMathInElement(document.body, {delimiters: [
                 {left: "$$", right: "$$", display: true},


### PR DESCRIPTION
This controls the slide number that is displayed in the lower right-hand side of the slide. To make this clear to the user so that they know how to modify this explicitly pass the default slide number format of

```html
'%current% / %total%'
```

The motivation to explicitly pass the default value is that a user might want to just have the format of

```html
slideNumberFormat: "%current%"
```

so that the audience isn't focused on the total number of slides in the deck (I do this now on my [fork's `master`](https://github.com/matthewfeickert/talk-template/commit/547e4e2c2251b47b0a02933e2b8904a33f96fd30)).

c.f. https://github.com/gnab/remark/wiki/Configuration